### PR TITLE
Update user story 15/add link to sort by on_loan=true, update spec test

### DIFF
--- a/app/controllers/artifacts_controller.rb
+++ b/app/controllers/artifacts_controller.rb
@@ -1,7 +1,7 @@
 class ArtifactsController < ApplicationController
 
   def index
-    @artifacts = Artifact.all
+    @artifacts = Artifact.only_display_if_true
   end
 
   def show

--- a/app/controllers/artifacts_controller.rb
+++ b/app/controllers/artifacts_controller.rb
@@ -1,7 +1,13 @@
 class ArtifactsController < ApplicationController
 
   def index
-    @artifacts = Artifact.only_display_if_true
+    # require 'pry'; binding.pry
+    if params[:sort] == "on_loan_true"
+      @artifacts = Artifact.only_display_if_true
+    else
+      @artifacts = Artifact.all
+    end
+    # @artifacts = Artifact.only_display_if_true(params[:order])
   end
 
   def show
@@ -25,7 +31,7 @@ class ArtifactsController < ApplicationController
 
   private
   def artifact_params
-   params.permit(:name, :material, :year_created, :total_pieces, :on_loan)
- end
+    params.permit(:name, :material, :year_created, :total_pieces, :on_loan)
+  end
   
 end

--- a/app/controllers/exhibits/artifacts_controller.rb
+++ b/app/controllers/exhibits/artifacts_controller.rb
@@ -9,10 +9,10 @@ class Exhibits::ArtifactsController < ApplicationController
   end
 
   def create
-    @exhibit = Exhibit.find(params[:id])
+    exhibit = Exhibit.find(params[:id])
     # Artifact.create!(artifact_params.merge({exhibit_id: @exhibit.id}))
-    @exhibit.artifacts.create!(artifact_params)
-    redirect_to "/exhibits/#{@exhibit.id}/artifacts"
+    exhibit.artifacts.create!(artifact_params)
+    redirect_to "/exhibits/#{exhibit.id}/artifacts"
   end
 
   private

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -34,7 +34,8 @@ class ExhibitsController < ApplicationController
 
   def destroy
     @exhibit = Exhibit.find(params[:id])
-    @exhibit.artifacts.destroy
+    # @exhibit.artifacts.destroy 
+    #artifacts is an attr. of exhibit...so it's also destroyed by line below:
     @exhibit.destroy
     redirect_to "/exhibits"
   end

--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -1,3 +1,12 @@
 class Artifact < ApplicationRecord
   belongs_to :exhibit
+
+  def self.only_display_if_true
+    where("on_loan")
+  end
+
+  # scope doesn't need a model test because it's called in the controller
+  # and becomes a "feature" ??
+  # If you're sorting/filter you can use scope
+  # scope :only_disply_if_true, -> (where("on_loan"))
 end

--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -1,11 +1,16 @@
 class Artifact < ApplicationRecord
   belongs_to :exhibit
+  # scope :only_display_if_true, ->  { where(on_loan: :true) }
 
   def self.only_display_if_true
-    where("on_loan")
+      where(on_loan: :true)
   end
 
-  # scope doesn't need a model test because it's called in the controller
+  # def self.sort_alphabetically
+  #   order(on_loan: :true)
+  # end
+
+  # scope does need a model test 
   # and becomes a "feature" ??
   # If you're sorting/filter you can use scope
   # scope :only_disply_if_true, -> (where("on_loan"))

--- a/app/models/exhibit.rb
+++ b/app/models/exhibit.rb
@@ -1,5 +1,13 @@
 class Exhibit < ApplicationRecord
   has_many :artifacts, dependent: :destroy
+ 
+  # validates :name, presence: true 
+  # validates on_loan, inclusion; [true, false]
+  #this makes it so that when a new record is created
+  # that field must be filled
+
+  #test to validate expect(name).to be_valid
+  # added example artifacts with nil values -> .to_not be_valid
 
   def count_of_artifacts
     artifacts.count

--- a/app/views/artifacts/index.html.erb
+++ b/app/views/artifacts/index.html.erb
@@ -1,4 +1,5 @@
 <h1>All Artifacts</h1>
+<p><%= link_to "Only View Artifact from Other Museums", :sort => "on_loan_true" %></p>
 
 <% @artifacts.each do |artifact| %>
   <h3><%= artifact.name %></h3> 

--- a/app/views/exhibits/artifacts/index.html.erb
+++ b/app/views/exhibits/artifacts/index.html.erb
@@ -7,6 +7,8 @@
   <p>Total Pieces: <%= artifact.total_pieces %></p>
   <p>On Loan from Another Museum: <%= artifact.on_loan %></p>
   <br>
+  <p><%= link_to "Update Artifact: #{artifact.name}", "/artifacts/#{artifact.id}/edit" %></p>
+  <br>
   <p><%= link_to "Delete Artifact: #{artifact.name}", "/artifacts/#{artifact.id}", method: :delete %></p>
   <br>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,9 @@ Rails.application.routes.draw do
   get '/exhibits', to:'exhibits#index'
   get '/exhibits/new', to: 'exhibits#new'
   post '/exhibits', to: 'exhibits#create'
-  patch '/exhibits/:id', to: 'exhibits#update'
   get '/exhibits/:id', to: 'exhibits#show'
   get '/exhibits/:id/edit', to: 'exhibits#edit'
+  patch '/exhibits/:id', to: 'exhibits#update'
   delete '/exhibits/:id', to: 'exhibits#destroy'
   
   get '/exhibits/:id/artifacts', to: 'exhibits/artifacts#index'
@@ -15,8 +15,8 @@ Rails.application.routes.draw do
   post '/exhibits/:id/artifacts', to: 'exhibits/artifacts#create'
 
   get '/artifacts', to: 'artifacts#index'
-  patch '/artifacts/:id', to: 'artifacts#update'
   get '/artifacts/:id', to: 'artifacts#show'
   get '/artifacts/:id/edit', to: 'artifacts#edit'
+  patch '/artifacts/:id', to: 'artifacts#update'
   delete '/artifacts/:id', to: 'artifacts#destroy'
 end

--- a/spec/features/artifacts/index_spec.rb
+++ b/spec/features/artifacts/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'the artifact index page' do
         artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", total_pieces: 1, on_loan: true) 
 
         visit "/artifacts"
-        
+
         expect(page).to have_content(artifact_1.name)
         expect(page).to have_content("Material: #{artifact_1.material}")
         expect(page).to have_content("Date Created: #{artifact_1.year_created}")
@@ -44,7 +44,8 @@ RSpec.describe 'the artifact index page' do
     end
   end
 
-  # If I test for this...will other tests(3) fail? 
+  # If I test for this...
+  # story 3 & 17 - artifact 1 I changed to true cuz the entire tests were failing!
   # describe 'user story 15' do
   #   describe 'when I visit "/artifacts"'do 
   #     it 'I only see artifact records where "on_loan" is true' do
@@ -55,6 +56,7 @@ RSpec.describe 'the artifact index page' do
 
   #       visit "/artifacts"
 
+  #       within ""
   #       expect(page).to_not have_content(artifact_1.name)
   #       expect(page).to_not have_content("Material: #{artifact_1.material}")
   #       expect(page).to_not have_content("Date Created: #{artifact_1.year_created}")

--- a/spec/features/artifacts/index_spec.rb
+++ b/spec/features/artifacts/index_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'the artifact index page' do
   #   end
   # end
 
-  describe 'user story 17' do
+  describe 'user story 18' do
     describe 'when I visit "/artifacts"' do
       it 'next to each record, I see a link to edit that artifact record' do
         exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00)

--- a/spec/features/artifacts/index_spec.rb
+++ b/spec/features/artifacts/index_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'the artifact index page' do
       it 'displays all the artifacts and their attributes' do
         exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00)
         artifact_1 = Artifact.create!(exhibit: exhibit_1, name: "Statue of Augustus", material: "Marble", year_created: "45 BCE", total_pieces: 5, on_loan: false) 
+        artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", total_pieces: 1, on_loan: true) 
 
         visit "/artifacts"
         
@@ -14,6 +15,13 @@ RSpec.describe 'the artifact index page' do
         expect(page).to have_content("Date Created: #{artifact_1.year_created}")
         expect(page).to have_content("Total Pieces: #{artifact_1.total_pieces}")
         expect(page).to have_content("On Loan from Another Museum: #{artifact_1.on_loan}")
+
+        expect(page).to have_content(artifact_2.name)
+        expect(page).to have_content("Material: #{artifact_2.material}")
+        expect(page).to have_content("Date Created: #{artifact_2.year_created}")
+        expect(page).to have_content("Total Pieces: #{artifact_2.total_pieces}")
+        expect(page).to have_content("On Loan from Another Museum: #{artifact_2.on_loan}")
+
       end
     end
   end
@@ -35,6 +43,25 @@ RSpec.describe 'the artifact index page' do
       end
     end
   end
+
+  # If I test for this...will other tests(3) fail? 
+  # describe 'user story 15' do
+  #   describe 'when I visit "/artifacts"'do 
+  #     it 'I only see artifact records where "on_loan" is true' do
+  #       exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00)
+  #       artifact_1 = Artifact.create!(exhibit: exhibit_1, name: "Statue of Augustus", material: "Marble", year_created: "45 BCE", total_pieces: 5, on_loan: false) 
+  #       artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Nummus Aureus Coin", material: "gold", year_created: "312 CE", total_pieces: 12, on_loan: true) 
+  #       artifact_3 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", total_pieces: 1, on_loan: true) 
+
+  #       visit "/artifacts"
+
+  #       expect(page).to_not have_content(artifact_1.name)
+  #       expect(page).to_not have_content("Material: #{artifact_1.material}")
+  #       expect(page).to_not have_content("Date Created: #{artifact_1.year_created}")
+  #       expect(page).to_not have_content("Total Pieces: #{artifact_1.total_pieces}")
+  #     end 
+  #   end
+  # end
 
   describe 'user story 17' do
     describe 'when I visit "/artifacts"' do
@@ -96,7 +123,7 @@ RSpec.describe 'the artifact index page' do
         expect(page).to_not have_content("Material: #{artifact_1.material}")
         expect(page).to_not have_content("Date Created: #{artifact_1.year_created}")
         expect(page).to_not have_content("Total Pieces: #{artifact_1.total_pieces}")
-         # Not sure what to do with this test: for now it passes but since its a boolean, most likely
+        # Not sure what to do with this test: for now it passes but since its a boolean, most likely
         # another artifact would have this same output
         # expect(page).to_not have_content("On Loan from Another Museum: #{artifact_1.on_loan}")
 

--- a/spec/features/artifacts/index_spec.rb
+++ b/spec/features/artifacts/index_spec.rb
@@ -44,26 +44,38 @@ RSpec.describe 'the artifact index page' do
     end
   end
 
-  # If I test for this...
-  # story 3 & 17 - artifact 1 I changed to true cuz the entire tests were failing!
-  # describe 'user story 15' do
-  #   describe 'when I visit "/artifacts"'do 
-  #     it 'I only see artifact records where "on_loan" is true' do
-  #       exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00)
-  #       artifact_1 = Artifact.create!(exhibit: exhibit_1, name: "Statue of Augustus", material: "Marble", year_created: "45 BCE", total_pieces: 5, on_loan: false) 
-  #       artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Nummus Aureus Coin", material: "gold", year_created: "312 CE", total_pieces: 12, on_loan: true) 
-  #       artifact_3 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", total_pieces: 1, on_loan: true) 
+  describe 'user story 15' do
+    describe 'when I visit "/artifacts"'do 
+      it 'next to each record, I see a link to sort that artifact record' do
+        visit "/artifacts" 
+       
+        expect(page).to have_link("Only View Artifact from Other Museums")
+      end 
 
-  #       visit "/artifacts"
+      it 'when I click on the link it displays only the artifacts with a true value for on_loan' do 
+        exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00)
+        artifact_1 = Artifact.create!(exhibit: exhibit_1, name: "Statue of Augustus", material: "marble", year_created: "45 BCE", total_pieces: 5, on_loan: false) 
+        
+        exhibit_2 = Exhibit.create!(name: "Ancient Korea", on_display: false, price: 17.00)
+        artifact_2 = Artifact.create!(exhibit: exhibit_2, name: "Roof-end Tile with Face Design", material: "tile", year_created: "800 BCE", total_pieces: 1, on_loan: false) 
+        artifact_3 = Artifact.create!(exhibit: exhibit_2, name: "Divine Bell of King Seongdeok", material: "metal", year_created: "771 BCE", total_pieces: 2, on_loan: true) 
 
-  #       within ""
-  #       expect(page).to_not have_content(artifact_1.name)
-  #       expect(page).to_not have_content("Material: #{artifact_1.material}")
-  #       expect(page).to_not have_content("Date Created: #{artifact_1.year_created}")
-  #       expect(page).to_not have_content("Total Pieces: #{artifact_1.total_pieces}")
-  #     end 
-  #   end
-  # end
+        visit "/artifacts" 
+
+        expect(page).to have_content(artifact_1.name)
+        expect(page).to have_content(artifact_2.name)
+        expect(page).to have_content(artifact_3.name)
+
+        click_link("Only View Artifact from Other Museums")
+
+        expect(current_path).to eq("/artifacts")      
+        expect(page).to have_content(artifact_3.name)
+
+        expect(page).to_not have_content(artifact_1.name)
+        expect(page).to_not have_content(artifact_2.name)
+      end
+    end
+  end
 
   describe 'user story 18' do
     describe 'when I visit "/artifacts"' do

--- a/spec/features/exhibits/artifacts/index_spec.rb
+++ b/spec/features/exhibits/artifacts/index_spec.rb
@@ -89,6 +89,32 @@ RSpec.describe 'the exhibit/artifacts index page' do
     end
   end
 
+  describe 'user story 18' do
+    describe 'when I visit "/exhibits/:id/artifacts"' do
+      it 'next to each record, I see a link to edit that artifact record' do
+        exhibit_1 = Exhibit.create!(name: "Ancient Korea", on_display: false, price: 17.00)
+        artifact_1 = Artifact.create!(exhibit: exhibit_1, name: "Roof-end Tile with Face Design", material: "tile", year_created: "800 BCE", total_pieces: 1, on_loan: true) 
+        artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Divine Bell of King Seongdeok", material: "metal", year_created: "771 BCE", total_pieces: 2, on_loan: true) 
+
+        visit "/exhibits/#{exhibit_1.id}/artifacts"
+
+        expect(page).to have_link("Update Artifact: #{artifact_1.name}")
+        expect(page).to have_link("Update Artifact: #{artifact_2.name}")
+      end
+
+      it 'when I click on the link it takes me to the artifacts edit page' do 
+        exhibit_1 = Exhibit.create!(name: "Ancient Korea", on_display: false, price: 17.00)
+        artifact_1 = Artifact.create!(exhibit: exhibit_1, name: "Roof-end Tile with Face Design", material: "tile", year_created: "800 BCE", total_pieces: 1, on_loan: true) 
+        artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Divine Bell of King Seongdeok", material: "metal", year_created: "771 BCE", total_pieces: 2, on_loan: true) 
+
+        visit "/exhibits/#{exhibit_1.id}/artifacts"
+        click_link("Update Artifact: #{artifact_2.name}")
+
+        expect(current_path).to eq("/artifacts/#{artifact_2.id}/edit")      
+      end
+    end
+  end
+
   describe 'user story 23' do
     describe 'when I visit "/exhibits/:id/artifacts"' do
       it 'next to each record, I see a link to delete that artifact record' do

--- a/spec/features/exhibits/artifacts/index_spec.rb
+++ b/spec/features/exhibits/artifacts/index_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe 'the exhibit/artifacts index page' do
     end
   end
 
+  describe 'user story 16' do
+    describe 'when I visit "/exhibits/:id/artifacts"' do
+      it 'I see a link to sort artifact records alphabetically' do
+
+      end
+    end
+  end
+
   describe 'user story 23' do
     describe 'when I visit "/exhibits/:id/artifacts"' do
       it 'next to each record, I see a link to delete that artifact record' do

--- a/spec/features/exhibits/index_spec.rb
+++ b/spec/features/exhibits/index_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe 'the exhibit index page' do
   describe 'user story 6' do
     describe 'when I visit "/exhibits"'do 
       it 'displays exhibits ordered by most recently created first' do
-        exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00, created_at: Time.now - 2.hour)
-        exhibit_2 = Exhibit.create!(name: "Ancient Korea", on_display: false, price: 17.00, created_at: Time.now - 1.hour)
+        exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00, created_at: Time.now - 3.hour)
+        exhibit_2 = Exhibit.create!(name: "Ancient Korea", on_display: false, price: 17.00, created_at: Time.now - 2.hour)
 
         visit "/exhibits"
 

--- a/spec/features/exhibits/index_spec.rb
+++ b/spec/features/exhibits/index_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe 'the exhibit index page' do
     end
   end
 
+
   describe 'user story 11' do
     describe 'when I visit "/exhibits"' do
       it 'I see a link to create a new exhibit record' do

--- a/spec/features/exhibits/show_spec.rb
+++ b/spec/features/exhibits/show_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe 'the exhibit show page' do
         exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00)
 
         artifact_1 = Artifact.create!(exhibit: exhibit_1, name: "Statue of Augustus", material: "marble", year_created: "45 BCE", on_loan: false, total_pieces: 5) 
-        artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Nummus Aureus Coin", material: "gold", year_created: "312 CE", on_loan: true, total_pieces: 12) 
-        artifact_3 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", on_loan: true, total_pieces: 1) 
+        artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Nummus Aureus Coin", material: "gold", year_created: "312 CE", total_pieces: 12, on_loan: true) 
+        artifact_3 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", total_pieces: 1, on_loan: true) 
         
         visit "/exhibits/#{exhibit_1.id}"
 

--- a/spec/features/exhibits/show_spec.rb
+++ b/spec/features/exhibits/show_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'the exhibit show page' do
         artifact_3 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", on_loan: true, total_pieces: 1) 
         
         visit "/exhibits/#{exhibit_1.id}"
+        save_and_open_page
 
         expect(page).to have_content("Number of Artifacts: #{exhibit_1.count_of_artifacts}")
       end

--- a/spec/models/artifact_spec.rb
+++ b/spec/models/artifact_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Artifact, type: :model do
         artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Nummus Aureus Coin", material: "gold", year_created: "312 CE", total_pieces: 12, on_loan: true) 
         artifact_3 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", total_pieces: 1, on_loan: true) 
 
-        expect(Artifact.only_disply_if_true).to eq([artifact_2, artifact_3])
+        expect(Artifact.only_display_if_true).to eq([artifact_2, artifact_3])
       end
     end
   end

--- a/spec/models/artifact_spec.rb
+++ b/spec/models/artifact_spec.rb
@@ -2,4 +2,18 @@ require 'rails_helper'
 
 RSpec.describe Artifact, type: :model do
   it {should belong_to :exhibit}
+
+  describe 'user story 15' do
+    describe '#only_disply_if_true"'do 
+      it 'only displays artifact records where "on_loan" is true' do
+        exhibit_1 = Exhibit.create!(name: "Ancient Rome", on_display: true, price: 15.00)
+        artifact_1 = Artifact.create!(exhibit: exhibit_1, name: "Statue of Augustus", material: "Marble", year_created: "45 BCE", total_pieces: 5, on_loan: false) 
+        artifact_2 = Artifact.create!(exhibit: exhibit_1, name: "Nummus Aureus Coin", material: "gold", year_created: "312 CE", total_pieces: 12, on_loan: true) 
+        artifact_3 = Artifact.create!(exhibit: exhibit_1, name: "Galdiator Cup", material: "glass", year_created: "75 BCE", total_pieces: 1, on_loan: true) 
+
+        expect(Artifact.only_disply_if_true).to eq([artifact_2, artifact_3])
+      end
+    end
+  end
+
 end

--- a/spec/models/exhibit_spec.rb
+++ b/spec/models/exhibit_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Exhibit, type: :model do
 
   it {should have_many :artifacts}
 
-  describe 'instance methods' do
     describe 'user story 6' do
       describe '#order_by_most_recently_created' do
         it 'displays the exhibits in order of most recetly created first' do
@@ -20,7 +19,6 @@ RSpec.describe Exhibit, type: :model do
         end
       end
     end
-  end
 
   describe 'user story 7' do
     describe '#count_of_artifacts' do


### PR DESCRIPTION
Based on lesson conversation, decided to add link to user story 15
The new link filters out artifacts where on_loan=false and only displays artifacts with on_loan=true
Updated artifact spec_test 

*NOTE: also realized User Story 18 was missing for exhibit/artifact 
- updated spec & added link in view